### PR TITLE
Fix Preference's "customized" output value

### DIFF
--- a/Model/Checker/Preferences.php
+++ b/Model/Checker/Preferences.php
@@ -28,7 +28,7 @@ class Preferences
         if (array_key_exists($path, $this->preferenceArray)) {
             return [
                 'patched' => $path,
-                'customized' => $this->preferenceArray[$path]
+                'customized' => [$this->preferenceArray[$path]]
             ];
         }
 

--- a/Test/Unit/Model/RunnerTest.php
+++ b/Test/Unit/Model/RunnerTest.php
@@ -111,7 +111,7 @@ class RunnerTest extends TestCase
         // Preference
         $this->assertEquals(
             $result['preferences']['vendor/magento/module-catalog-rule/Controller/Adminhtml/Promo/Catalog/Save.php'],
-            'SomethingDigitalUpgradeHelper\Module\Controller\Adminhtml\Promo\Catalog\Save'
+            ['SomethingDigitalUpgradeHelper\Module\Controller\Adminhtml\Promo\Catalog\Save']
         );
 
         // Theme (app/design) .phtml multiple overrides of the same file in different themes


### PR DESCRIPTION
Since #34, `customized` should now be in array-type.
But `Preference` was not reflecting that change.

Fixed `Model/Checker/Preferences` and `Test/Unit/Model/RunnerTest`