### PR TITLE
Improve performance by indexing file paths

### DIFF
--- a/Console/UpgradeHelperCommand.php
+++ b/Console/UpgradeHelperCommand.php
@@ -2,6 +2,7 @@
 
 namespace SomethingDigital\UpgradeHelper\Console;
 
+use SomethingDigital\UpgradeHelper\Model\FileIndex;
 use SomethingDigital\UpgradeHelper\Model\Runner;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -13,11 +14,15 @@ class UpgradeHelperCommand extends Command
 {
     private $runner;
 
+    private $fileIndex;
+
     public function __construct(
-        Runner $runner
+        Runner $runner,
+        FileIndex $fileIndex
     ) {
         parent::__construct(null);
         $this->runner = $runner;
+        $this->fileIndex = $fileIndex;
     }
 
     protected function configure()
@@ -36,6 +41,9 @@ class UpgradeHelperCommand extends Command
         $result = [];
         $result['preferences'] = [];
         $result['overrides'] = [];
+
+        $output->writeln('Populating file override index...');
+        $this->fileIndex->populateIndex();
 
         $progressBar = new ProgressBar($output, $lines);
         $progressBar->setFormat('Lines in diff processed: %current%/%max% [%bar%] %percent:3s%% (elapsed: %elapsed% | remaining: ~%remaining%)');

--- a/Model/Checker/Overrides.php
+++ b/Model/Checker/Overrides.php
@@ -2,6 +2,8 @@
 
 namespace SomethingDigital\UpgradeHelper\Model\Checker;
 
+use SomethingDigital\UpgradeHelper\Model\FileIndex;
+
 class Overrides
 {
     private $interestingExtensions = [
@@ -16,6 +18,14 @@ class Overrides
     ];
 
     private $endPosition;
+
+    private $fileIndex;
+
+    public function __construct(
+        FileIndex $fileIndex
+    ) {
+        $this->fileIndex = $fileIndex;
+    }
 
     /**
      * Command for checking modules
@@ -57,14 +67,11 @@ class Overrides
         }
 
         $this->endPosition = strpos($path, $pathInfo['basename']);
-
-        $moduleResults = explode(PHP_EOL, trim(shell_exec($this->moduleCmd($pathInfo))));
-        $themeResults = explode(PHP_EOL, trim(shell_exec($this->themeCmd($pathInfo))));
-        $results = array_merge($moduleResults, $themeResults);
+        
+        $results = $this->fileIndex->getOverrideResults($pathInfo);
         $output = [];
 
         foreach ($results as $result) {
-            $result = substr($result, 2);
             if ($this->isOverride($result, $path)) {
                 $customized[] = $result;
             }

--- a/Model/Checker/Overrides.php
+++ b/Model/Checker/Overrides.php
@@ -6,54 +6,12 @@ use SomethingDigital\UpgradeHelper\Model\FileIndex;
 
 class Overrides
 {
-    private $interestingExtensions = [
-        'phtml',
-        'js',
-        'html',
-        'less'
-    ];
-
-    private $whitelistedBasenames = [
-        'requirejs-config.js'
-    ];
-
-    private $endPosition;
-
     private $fileIndex;
 
     public function __construct(
         FileIndex $fileIndex
     ) {
         $this->fileIndex = $fileIndex;
-    }
-
-    /**
-     * Command for checking modules
-     *
-     * Example command:
-     * find . -name gift-card-account.js -path '*\/view/frontend/web/js/view/cart/totals/*'
-     */
-    private function moduleCmd($pathInfo)
-    {
-        $start = strpos($pathInfo['fullpath'], '/view/');
-        $path = substr($pathInfo['fullpath'], $start, $this->endPosition - $start);
-
-        return "find . -name " . $pathInfo['basename'] . " -path '*" . $path . "*'";
-    }
-
-    /**
-     * Command for checking theme
-     *
-     * Example command:
-     * find . -name gift-card-account.js -path '*app/design/*' -path '*web/js/view/cart/totals/*'
-     */
-    private function themeCmd($pathInfo)
-    {
-        $startKey = '/frontend/';
-        $startPos = strpos($pathInfo['fullpath'], $startKey) + strlen($startKey);
-        $path = substr($pathInfo['fullpath'], $startPos, $this->endPosition - $startPos);
-
-        return "find . -name " . $pathInfo['basename'] . " -path '*app/design/*' -path '*" . $path . "*'";
     }
 
     /**
@@ -65,8 +23,6 @@ class Overrides
         if (!$this->shouldCheck($pathInfo)) {
             return [];
         }
-
-        $this->endPosition = strpos($path, $pathInfo['basename']);
         
         $results = $this->fileIndex->getOverrideResults($pathInfo);
         $output = [];
@@ -93,11 +49,11 @@ class Overrides
             return false;
         }
 
-        if (!in_array($pathInfo['extension'], $this->interestingExtensions)) {
+        if (!in_array($pathInfo['extension'], FileIndex::INTERESTING_EXTENSIONS)) {
             return false;
         }
 
-        if (in_array($pathInfo['basename'], $this->whitelistedBasenames)) {
+        if (in_array($pathInfo['basename'], FileIndex::WHITELISTED_BASENAMES)) {
             return false;
         }
 

--- a/Model/FileIndex.php
+++ b/Model/FileIndex.php
@@ -88,6 +88,8 @@ class FileIndex
     }
 
     /**
+     * Example: '/^.+\.(phtml|js|html|less)$/i';
+     *
      * @return string
      */
     private function getFilePattern(): string
@@ -97,6 +99,12 @@ class FileIndex
     }
 
     /**
+     * Module override example:
+     * vendor/magento/module-sales-rule/view/frontend/web/js/action/set-coupon-code.js => /view/frontend/web/js/action/
+     *
+     * Theme override example:
+     * vendor/magento/module-sales-rule/view/frontend/web/js/action/set-coupon-code.js => /web/js/action/
+     *
      * @param string $basename
      * @param string $fullPath
      * @param string $overrideType
@@ -105,7 +113,7 @@ class FileIndex
     private function getSubPath(string $basename, string $fullPath, string $overrideType): string
     {
         $baseDir = $overrideType === self::THEME_OVERRIDE ? '/frontend/' : '/view/';
-        $offset = $overrideType === self::THEME_OVERRIDE ? strlen($baseDir) : 0;
+        $offset = $overrideType === self::THEME_OVERRIDE ? strlen($baseDir) - 1 : 0;
         $startPos = strpos($fullPath, $baseDir) + $offset;
         $endPos = strpos($fullPath, $basename);
         return substr($fullPath, $startPos, $endPos - $startPos);

--- a/Model/FileIndex.php
+++ b/Model/FileIndex.php
@@ -15,6 +15,10 @@ class FileIndex
             'less'
     ];
 
+    const WHITELISTED_BASENAMES = [
+        'requirejs-config.js'
+    ];
+
     /**
      * @var array[]
      */
@@ -41,8 +45,8 @@ class FileIndex
      */
     public function getOverrideResults(array $pathInfo): array
     {
-        $moduleResults = $this->getResultsByType($pathInfo, self::MODULE_OVERRIDE);
-        $themeResults = $this->getResultsByType($pathInfo, self::THEME_OVERRIDE);
+        $moduleResults = $this->getResultsByOverrideType($pathInfo, self::MODULE_OVERRIDE);
+        $themeResults = $this->getResultsByOverrideType($pathInfo, self::THEME_OVERRIDE);
         return array_merge($moduleResults, $themeResults);
     }
 
@@ -58,9 +62,12 @@ class FileIndex
         $directory = new \RecursiveDirectoryIterator($basePath);
         $iterator = new \RecursiveIteratorIterator($directory);
         $regexIterator = new \RegexIterator($iterator, $filePattern, \RecursiveRegexIterator::GET_MATCH);
+
         foreach ($regexIterator as $dirInfo) {
             $fullPath = $dirInfo[0];
-            $this->index[$overrideType][basename($fullPath)][] = $fullPath;
+            if (!in_array(basename($fullPath), self::WHITELISTED_BASENAMES)) {
+                $this->index[$overrideType][basename($fullPath)][] = $fullPath;
+            }
         }
     }
 

--- a/Model/FileIndex.php
+++ b/Model/FileIndex.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace SomethingDigital\UpgradeHelper\Model;
+
+class FileIndex
+{
+    const THEME_OVERRIDE = 'theme_override';
+
+    const MODULE_OVERRIDE = 'module_override';
+
+    const INTERESTING_EXTENSIONS = [
+            'phtml',
+            'js',
+            'html',
+            'less'
+    ];
+
+    /**
+     * @var array[]
+     */
+    private $index;
+
+    public function __construct()
+    {
+        $this->index = [
+            self::THEME_OVERRIDE => [],
+            self::MODULE_OVERRIDE => [],
+        ];
+    }
+
+    public function populateIndex(): void
+    {
+        $this->populateIndexForPath(self::THEME_OVERRIDE, 'app/design/');
+        $this->populateIndexForPath(self::MODULE_OVERRIDE, 'vendor/');
+        $this->populateIndexForPath(self::MODULE_OVERRIDE, 'app/code/');
+    }
+
+    /**
+     * @param array $pathInfo
+     * @return array
+     */
+    public function getOverrideResults(array $pathInfo): array
+    {
+        $moduleResults = $this->getResultsByType($pathInfo, self::MODULE_OVERRIDE);
+        $themeResults = $this->getResultsByType($pathInfo, self::THEME_OVERRIDE);
+        return array_merge($moduleResults, $themeResults);
+    }
+
+    /**
+     * @param string $overrideType
+     * @param string $basePath
+     */
+    private function populateIndexForPath(
+        string $overrideType,
+        string $basePath
+    ): void {
+        $filePattern = $this->getFilePattern();
+        $directory = new \RecursiveDirectoryIterator($basePath);
+        $iterator = new \RecursiveIteratorIterator($directory);
+        $regexIterator = new \RegexIterator($iterator, $filePattern, \RecursiveRegexIterator::GET_MATCH);
+        foreach ($regexIterator as $dirInfo) {
+            $fullPath = $dirInfo[0];
+            $this->index[$overrideType][basename($fullPath)][] = $fullPath;
+        }
+    }
+
+    /**
+     * @param array $pathInfo
+     * @param string $overrideType
+     * @return array
+     */
+    private function getResultsByOverrideType(array $pathInfo, string $overrideType): array
+    {
+        $basenameFromDiff = $pathInfo['basename'];
+        $fullPathFromDiff = $pathInfo['fullpath'];
+        $subPath = $this->getSubPath($basenameFromDiff, $fullPathFromDiff, $overrideType);
+        $fullPaths = $this->index[$overrideType][$basenameFromDiff] ?? [];
+        return array_filter($fullPaths, function ($fullPath) use ($subPath) {
+            return strpos($fullPath, $subPath) !== false;
+        });
+    }
+
+    /**
+     * @return string
+     */
+    private function getFilePattern(): string
+    {
+        $fileExtensionGroup = implode('|', self::INTERESTING_EXTENSIONS);
+        return "/^.+\.($fileExtensionGroup)\$/i";
+    }
+
+    /**
+     * @param string $basename
+     * @param string $fullPath
+     * @param string $overrideType
+     * @return string
+     */
+    private function getSubPath(string $basename, string $fullPath, string $overrideType): string
+    {
+        $baseDir = $overrideType === self::THEME_OVERRIDE ? '/frontend/' : '/view/';
+        $offset = $overrideType === self::THEME_OVERRIDE ? strlen($baseDir) : 0;
+        $startPos = strpos($fullPath, $baseDir) + $offset;
+        $endPos = strpos($fullPath, $basename);
+        return substr($fullPath, $startPos, $endPos - $startPos);
+    }
+}

--- a/Test/Unit/Model/RunnerTest.php
+++ b/Test/Unit/Model/RunnerTest.php
@@ -54,7 +54,6 @@ class RunnerTest extends TestCase
                 'lineProcessor' => $this->lineProcessor,
                 'overrideChecker' => $this->overrideChecker,
                 'preferenceChecker' => $this->preferenceChecker,
-
             ]
         );
 
@@ -87,7 +86,6 @@ class RunnerTest extends TestCase
                 $result['overrides']['vendor/magento/module-sales-rule/view/frontend/web/js/action/set-coupon-code.js'],
                 [
                     'app/design/frontend/SomethingDigitalUpgradeHelper/theme/Magento_SalesRule/web/js/action/set-coupon-code.js',
-                    'app/code/SomethingDigital/UpgradeHelper/Test/Fixtures/app/design/frontend/SomethingDigitalUpgradeHelper/theme/Magento_SalesRule/web/js/action/set-coupon-code.js'
                 ]
             )
         );
@@ -98,7 +96,6 @@ class RunnerTest extends TestCase
                 $result['overrides']['vendor/magento/module-bundle/view/frontend/templates/js/components.phtml'],
                 [
                     'app/design/frontend/SomethingDigitalUpgradeHelper/theme/Magento_Catalog/templates/js/components.phtml',
-                    'app/code/SomethingDigital/UpgradeHelper/Test/Fixtures/app/design/frontend/SomethingDigitalUpgradeHelper/theme/Magento_Catalog/templates/js/components.phtml'
                 ]
             )
         );
@@ -138,8 +135,6 @@ class RunnerTest extends TestCase
                 [
                     'app/design/frontend/SomethingDigitalUpgradeHelper/theme2/Magento_Customer/templates/form/forgotpassword.phtml',
                     'app/design/frontend/SomethingDigitalUpgradeHelper/theme/Magento_Customer/templates/form/forgotpassword.phtml',
-                    'app/code/SomethingDigital/UpgradeHelper/Test/Fixtures/app/design/frontend/SomethingDigitalUpgradeHelper/theme2/Magento_Customer/templates/form/forgotpassword.phtml',
-                    'app/code/SomethingDigital/UpgradeHelper/Test/Fixtures/app/design/frontend/SomethingDigitalUpgradeHelper/theme/Magento_Customer/templates/form/forgotpassword.phtml'
                 ]
             )
         );
@@ -159,6 +154,9 @@ class RunnerTest extends TestCase
      * @return bool
      */
     protected function arrays_are_similar($a, $b) {
+        sort($a);
+        sort($b);
+
         // if the indexes don't match, return immediately
         if (count(array_diff_assoc($a, $b))) {
             return false;


### PR DESCRIPTION
### Changes 
- Added FileIndex class to cache file paths for each unique basename for JS, PHTML, HTML and LESS files under  app/design/, app/code/ and vendor/
- When checking for overrides, look up the basename in the index instead of using the `find` command
- Memory usage doesn't seem to be too bad, despite the full index being stored in memory. Based on the test runs, memory usage was around 12-14MB 

### Tests
- Previously, the tests were checking that the module would flag theme overrides under app/code (e.g. app/code/SomethingDigital/UpgradeHelper/Test/Fixtures/app/design/frontend/SomethingDigitalUpgradeHelper/theme/Magento_SalesRule/web/js/action/set-coupon-code.js)
- These tests have been removed
- Result arrays are now sorted before being compared since the order of the values shouldn't matter

### Performance Benchmarks
- I ran the command on a client docker environment, comparing v2.3.5-p2 to the 2.3.6 diff (95,880 lines)

master branch:
```
$ time bin/magento sd:dev:upgrade-helper var/magento-2.3.5-p2-ee--2.3.6-ee.diff
...
real	21m6.459s
user	1m25.874s
sys	2m55.939s
```
this branch:
```
$ time bin/magento sd:dev:upgrade-helper var/magento-2.3.5-p2-ee--2.3.6-ee.diff
...
real	0m19.164s
user	0m11.222s
sys	0m2.317s
```


CW Code Review Ticket: #415975 