### PR TITLE
Fix error with magento 2.4.6

### DIFF
--- a/Console/UpgradeHelperCommand.php
+++ b/Console/UpgradeHelperCommand.php
@@ -74,4 +74,5 @@ class UpgradeHelperCommand extends Command
             }
         }
     }
+    return Command::SUCCESS;
 }


### PR DESCRIPTION
There is an error in /var/www/html/vendor/symfony/console/Command/Command.php at line: 301
Return value of "SomethingDigital\UpgradeHelper\Console\UpgradeHelperCommand\Interceptor::execute()" must be of the type int, "null" returned.#0 /var/www/html/vendor/magento/framework/Interception/Interceptor.php(58): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#1 /var/www/html/vendor/magento/framework/Interception/Interceptor.php(138): SomethingDigital\UpgradeHelper\Console\UpgradeHelperCommand\Interceptor->___callParent('run', Array)
#2 /var/www/html/vendor/magento/framework/Interception/Interceptor.php(153): SomethingDigital\UpgradeHelper\Console\UpgradeHelperCommand\Interceptor->Magento\Framework\Interception\{closure}(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#3 /var/www/html/generated/code/SomethingDigital/UpgradeHelper/Console/UpgradeHelperCommand/Interceptor.php(77): SomethingDigital\UpgradeHelper\Console\UpgradeHelperCommand\Interceptor->___callPlugins('run', Array, Array)
#4 /var/www/html/vendor/symfony/console/Application.php(1040): SomethingDigital\UpgradeHelper\Console\UpgradeHelperCommand\Interceptor->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#5 /var/www/html/vendor/symfony/console/Application.php(301): Symfony\Component\Console\Application->doRunCommand(Object(SomethingDigital\UpgradeHelper\Console\UpgradeHelperCommand\Interceptor), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 /var/www/html/vendor/magento/framework/Console/Cli.php(116): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /var/www/html/vendor/symfony/console/Application.php(171): Magento\Framework\Console\Cli->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 /var/www/html/bin/magento(23): Symfony\Component\Console\Application->run()
#9 {main}

if cmd output is not int then it throwing error here https://github.com/symfony/console/blob/3582d68a64a86ec25240aaa521ec8bc2342b369b/Command/Command.php#L315