### PR TITLE
Fix syntax error from previous PR #43

### DIFF
--- a/Console/UpgradeHelperCommand.php
+++ b/Console/UpgradeHelperCommand.php
@@ -12,6 +12,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class UpgradeHelperCommand extends Command
 {
+    const SUCCESS = 0;
+
     private $runner;
 
     private $fileIndex;
@@ -73,6 +75,6 @@ class UpgradeHelperCommand extends Command
                 }
             }
         }
-        return Command::SUCCESS;
+        return self::SUCCESS;
     }
 }

--- a/Console/UpgradeHelperCommand.php
+++ b/Console/UpgradeHelperCommand.php
@@ -73,6 +73,6 @@ class UpgradeHelperCommand extends Command
                 }
             }
         }
+        return Command::SUCCESS;
     }
-    return Command::SUCCESS;
 }


### PR DESCRIPTION
Previous PR #43 
syntax error, unexpected token "return", expecting "function" or "const"#0 /var/www/html/vendor/composer/ClassLoader.php(428): Composer\Autoload\includeFile('/var/www/html/v...')