### PR TITLE
Fix line check with 'diff'

### DIFF
--- a/Model/LineProcessor.php
+++ b/Model/LineProcessor.php
@@ -22,8 +22,8 @@ class LineProcessor
      */
     public function toPathInfo($line)
     {
-        // Skip lines that don't start with `diff -r`
-        if (strpos($line, 'diff -r') !== 0) {
+        // Skip lines that don't start with `diff`
+        if (strpos($line, 'diff') !== 0) {
             return [];
         }
 


### PR DESCRIPTION
The line would fail if we check for `diff -r` and if the line had `diff --color -r`.

This PR addresses this issue by only checking for `diff` instead.

**UNIT TEST (on a clean Magento installation)**

<img width="967" alt="Screenshot 2024-08-20 at 2 23 57 PM" src="https://github.com/user-attachments/assets/8258344c-26f2-4785-8ce9-aa8719b0d2fa">


```
~/Projects/magento-upgrade/magento-2-4-5-p9-upgrade-helper-test/app/code/SomethingDigital/UpgradeHelper    02:17:05 PM
❯ make
cp Test/Unit/phpunit.xml.dist ../../../../dev/tests/unit/phpunit.xml
cp -r Test/Fixtures/app/design/frontend/SomethingDigitalUpgradeHelper ../../../../app/design/frontend/
cp -r Test/Fixtures/app/code/SomethingDigitalUpgradeHelper ../../../../app/code/
cp -r Test/Fixtures/vendor/somethingdigitalupgradehelper ../../../../vendor/
cd ../../../../; vendor/bin/phpunit -c dev/tests/unit/phpunit.xml
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

.                                                                                                          1 / 1 (100%)

Time: 00:02.287, Memory: 12.00 MB

OK (1 test, 7 assertions)
rm -rf ../../../../app/design/frontend/SomethingDigitalUpgradeHelper
rm -rf ../../../../app/code/SomethingDigitalUpgradeHelper
rm -rf ../../../../vendor/somethingdigitalupgradehelper
```