### PR TITLE
Fix PHP 8.2 deprecated dynamic property error

### DIFF
--- a/Test/Unit/Model/RunnerTest.php
+++ b/Test/Unit/Model/RunnerTest.php
@@ -20,6 +20,7 @@ class RunnerTest extends TestCase
     private $objectManagerConfig;
     private $preferenceChecker;
     private $fileIndex;
+    private $emailTemplateChecker;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
Error details:

There was 1 error:

1) SomethingDigital\UpgradeHelper\Test\Unit\Model\RunnerTest::testRun PHPUnit\Framework\Exception: Deprecated: Creation of dynamic property SomethingDigital\UpgradeHelper\Test\Unit\Model\RunnerTest::$emailTemplateChecker is deprecated in /Users/mukeshchapagain/Projects/VintageParts-VintageParts/app/code/SomethingDigital/UpgradeHelper/Test/Unit/Model/RunnerTest.php:52.