### PR TITLE
Remove setting area code on Email Template Checker

### DIFF
--- a/Model/Checker/EmailTemplate.php
+++ b/Model/Checker/EmailTemplate.php
@@ -5,7 +5,6 @@ namespace SomethingDigital\UpgradeHelper\Model\Checker;
 use SomethingDigital\UpgradeHelper\Model\FileIndex;
 use Magento\Email\Model\TemplateFactory as CoreEmailTemplateFactory;
 use Magento\Email\Model\Template\Config;
-use Magento\Framework\App\State as AppState;
 
 class EmailTemplate
 {
@@ -17,21 +16,16 @@ class EmailTemplate
 
     private $templateMappings = [];
 
-    private $appState;
-
     public function __construct(
         CoreEmailTemplateFactory $emailTemplateFactory,
-        Config $config,
-        AppState $appState
+        Config $config
     ) {
-        $this->appState = $appState;
         $this->emailTemplateFactory = $emailTemplateFactory;
         $this->config = $config;
     }
 
     public function mapEmailTemplates()
     {
-        $this->appState->setAreaCode(\Magento\Framework\App\Area::AREA_FRONTEND);
         $emailTemplateCollection = $this->emailTemplateFactory->create()->getCollection();
 
         foreach ($emailTemplateCollection as $template) {


### PR DESCRIPTION
While running upgrade-helper command:

```
bin/magento sd:dev:upgrade-helper magento-2-4-5-p8-ee--2-4-5-p9-ee.diff
```

I got the following error:

```
[2024-08-20T18:54:24.989439+00:00] main.ERROR: Area code is already set
#0 /var/www/html/vendor/magento/framework/Interception/Interceptor.php(58): Magento\Framework\App\State->setAreaCode('frontend')
#1 /var/www/html/vendor/magento/framework/Interception/Interceptor.php(138): Magento\Framework\App\State\Interceptor->___callParent('setAreaCode', Array)
#2 /var/www/html/vendor/magento/framework/Interception/Interceptor.php(153): Magento\Framework\App\State\Interceptor->Magento\Framework\Interception\{closure}('frontend')
#3 /var/www/html/generated/code/Magento/Framework/App/State/Interceptor.php(41): Magento\Framework\App\State\Interceptor->___callPlugins('setAreaCode', Array, Array)
#4 /var/www/html/app/code/SomethingDigital/UpgradeHelper/Model/Checker/EmailTemplate.php(34): Magento\Framework\App\State\Interceptor->setAreaCode('frontend')
#5 /var/www/html/app/code/SomethingDigital/UpgradeHelper/Model/Checker/EmailTemplate.php(51): SomethingDigital\UpgradeHelper\Model\Checker\EmailTemplate->mapEmailTemplates()
#6 /var/www/html/app/code/SomethingDigital/UpgradeHelper/Model/Runner.php(53): SomethingDigital\UpgradeHelper\Model\Checker\EmailTemplate->check(Array)
#7 /var/www/html/app/code/SomethingDigital/UpgradeHelper/Console/UpgradeHelperCommand.php(57): SomethingDigital\UpgradeHelper\Model\Runner->run('diff --color -r...')
#8 /var/www/html/vendor/symfony/console/Command/Command.php(255): SomethingDigital\UpgradeHelper\Console\UpgradeHelperCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#9 /var/www/html/vendor/magento/framework/Interception/Interceptor.php(58): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#10 /var/www/html/vendor/magento/framework/Interception/Interceptor.php(138): SomethingDigital\UpgradeHelper\Console\UpgradeHelperCommand\Interceptor->___callParent('run', Array)
#11 /var/www/html/vendor/magento/framework/Interception/Interceptor.php(153): SomethingDigital\UpgradeHelper\Console\UpgradeHelperCommand\Interceptor->Magento\Framework\Interception\{closure}(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#12 /var/www/html/generated/code/SomethingDigital/UpgradeHelper/Console/UpgradeHelperCommand/Interceptor.php(77): SomethingDigital\UpgradeHelper\Console\UpgradeHelperCommand\Interceptor->___callPlugins('run', Array, Array)
#13 /var/www/html/vendor/symfony/console/Application.php(1021): SomethingDigital\UpgradeHelper\Console\UpgradeHelperCommand\Interceptor->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#14 /var/www/html/vendor/symfony/console/Application.php(275): Symfony\Component\Console\Application->doRunCommand(Object(SomethingDigital\UpgradeHelper\Console\UpgradeHelperCommand\Interceptor), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#15 /var/www/html/vendor/magento/framework/Console/Cli.php(116): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#16 /var/www/html/vendor/symfony/console/Application.php(149): Magento\Framework\Console\Cli->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#17 /var/www/html/bin/magento(23): Symfony\Component\Console\Application->run()
#18 {main} [] []
```

This PR removes the setting of area code in the Email Template Checker class.