### PR TITLE
Fix Area code is not set issue

### DIFF
--- a/Console/UpgradeHelperCommand.php
+++ b/Console/UpgradeHelperCommand.php
@@ -9,6 +9,8 @@ use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Magento\Framework\App\State;
+use Magento\Framework\App\Area;
 
 class UpgradeHelperCommand extends Command
 {
@@ -18,13 +20,17 @@ class UpgradeHelperCommand extends Command
 
     private $fileIndex;
 
+    private $appState;
+
     public function __construct(
         Runner $runner,
-        FileIndex $fileIndex
+        FileIndex $fileIndex,
+        State $appState
     ) {
         parent::__construct(null);
         $this->runner = $runner;
         $this->fileIndex = $fileIndex;
+        $this->appState = $appState;
     }
 
     protected function configure()
@@ -37,6 +43,7 @@ class UpgradeHelperCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->appState->setAreaCode(Area::AREA_GLOBAL);
         $diff = file($input->getArgument('diff'));
         $lines = count($diff);
 


### PR DESCRIPTION

Fix the "Area code is not set" issue that occurs while running the upgrade helper command.

<img width="803" alt="Screenshot 2024-08-28 at 4 12 52 PM" src="https://github.com/user-attachments/assets/5e19ce4f-556a-4e6f-9c3e-b40f0114f28d">
